### PR TITLE
Fix: Resolve session_state modification error for selectboxes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1476,12 +1476,12 @@ def show_create_prescription():
                 "frequency": frequency, "duration": duration, "instructions": med_instructions
             })
             # Clear inputs for next medication
-            st.session_state.med_select = None # This might not work as expected for selectbox, needs unique key if we want to clear
-            st.session_state.med_dosage = ""
-            st.session_state.med_frequency = ""
-            st.session_state.med_duration = ""
-            st.session_state.med_instructions = ""
-            st.rerun() # Rerun to update list and clear some fields (selectbox might need specific handling)
+            # The selectbox (med_select) will reset/retain value based on Streamlit's default behavior on rerun
+            if 'med_dosage' in st.session_state: st.session_state.med_dosage = ""
+            if 'med_frequency' in st.session_state: st.session_state.med_frequency = ""
+            if 'med_duration' in st.session_state: st.session_state.med_duration = ""
+            if 'med_instructions' in st.session_state: st.session_state.med_instructions = ""
+            st.rerun()
         else:
             st.error("Please fill in Medication, Dosage, Frequency, and Duration.")
 
@@ -1521,9 +1521,9 @@ def show_create_prescription():
                 "urgency": lab_urgency, "instructions": lab_instructions
             })
             # Clear inputs
-            st.session_state.lab_select = None
-            st.session_state.lab_urgency = "Routine"
-            st.session_state.lab_instructions = ""
+            # The selectbox (lab_select) will reset/retain value based on Streamlit's default behavior on rerun
+            if 'lab_urgency' in st.session_state: st.session_state.lab_urgency = "Routine" # Reset to default
+            if 'lab_instructions' in st.session_state: st.session_state.lab_instructions = ""
             st.rerun()
         else:
             st.error("Please select a Lab Test.")


### PR DESCRIPTION
This commit fixes an error in the "Create Prescription" feature where attempting to programmatically set a selectbox's session state to None (e.g., `st.session_state.med_select = None`) after adding an item caused a "cannot be modified after the widget is instantiated" error.

The fix involves:
- Removing direct assignments of `None` to selectbox session state keys (`med_select`, `lab_select`) after item addition. These widgets will now rely on Streamlit's default behavior on `st.rerun()`.
- Ensuring text input fields for medication and lab test details are cleared by setting their session state to `""`.
- Resetting the `lab_urgency` selectbox to its default value "Routine".

This commit also includes all prior fixes.